### PR TITLE
Adding sample data to penguins

### DIFF
--- a/examples/quickstart/notebook.ipynb
+++ b/examples/quickstart/notebook.ipynb
@@ -28,7 +28,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 1,
    "metadata": {
     "tags": []
    },
@@ -45,7 +45,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -80,36 +80,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<table>\n",
-       "    <thead>\n",
-       "        <tr>\n",
-       "            <th>Count</th>\n",
-       "        </tr>\n",
-       "    </thead>\n",
-       "    <tbody>\n",
-       "    </tbody>\n",
-       "</table>"
-      ],
-      "text/plain": [
-       "+-------+\n",
-       "| Count |\n",
-       "+-------+\n",
-       "+-------+"
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "%%sql\n",
     "CREATE TABLE penguins AS\n",
@@ -120,7 +95,99 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%sql\n",
+    "CREATE TEMPORARY TABLE filtered_penguins AS\n",
+    "SELECT *\n",
+    "FROM penguins\n",
+    "WHERE species = 'Adelie'\n",
+    "  AND island = 'Biscoe'\n",
+    "  AND (sex = 'MALE' or sex = 'FEMALE');\n",
+    "\n",
+    "UPDATE filtered_penguins\n",
+    "SET island = 'Dream', species = 'Gentoo';\n",
+    "\n",
+    "INSERT INTO penguins\n",
+    "SELECT * FROM filtered_penguins;\n",
+    "\n",
+    "DROP TABLE filtered_penguins;"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%sql\n",
+    "CREATE TEMPORARY TABLE filtered_penguins AS\n",
+    "SELECT *\n",
+    "FROM penguins\n",
+    "WHERE species = 'Gentoo'\n",
+    "  AND island = 'Biscoe'\n",
+    "  AND (sex = 'MALE' or sex = 'FEMALE');\n",
+    "\n",
+    "UPDATE filtered_penguins\n",
+    "SET island = 'Torgersen';\n",
+    "\n",
+    "INSERT INTO penguins\n",
+    "SELECT * FROM filtered_penguins;\n",
+    "\n",
+    "DROP TABLE filtered_penguins;"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%sql\n",
+    "CREATE TEMPORARY TABLE filtered_penguins AS\n",
+    "SELECT *\n",
+    "FROM penguins\n",
+    "WHERE species = 'Gentoo'\n",
+    "  AND island = 'Biscoe'\n",
+    "  AND (sex = 'MALE' or sex = 'FEMALE');\n",
+    "\n",
+    "UPDATE filtered_penguins\n",
+    "SET species = 'Chinstrap', island = 'Torgersen';\n",
+    "\n",
+    "INSERT INTO penguins\n",
+    "SELECT * FROM filtered_penguins;\n",
+    "\n",
+    "DROP TABLE filtered_penguins;"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%sql\n",
+    "CREATE TEMPORARY TABLE filtered_penguins AS\n",
+    "SELECT *\n",
+    "FROM penguins\n",
+    "WHERE species = 'Gentoo'\n",
+    "  AND island = 'Biscoe'\n",
+    "  AND (sex = 'MALE' or sex = 'FEMALE');\n",
+    "\n",
+    "UPDATE filtered_penguins\n",
+    "SET species = 'Chinstrap';\n",
+    "\n",
+    "INSERT INTO penguins\n",
+    "SELECT * FROM filtered_penguins;\n",
+    "\n",
+    "DROP TABLE filtered_penguins;"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "tags": []
    },
@@ -138,7 +205,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {
     "tags": []
    },
@@ -160,27 +227,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "dc6bc85136164a868ea0f54d0eea6f91",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "TwoByTwoLayout(children=(SelectMultiple(description='Island', index=(0, 1, 2), layout=Layout(grid_area='top-le…"
-      ]
-     },
-     "execution_count": 9,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "widget_island = widgets.SelectMultiple(\n",
     "    options=islands,\n",
@@ -214,7 +265,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {
     "tags": []
    },
@@ -228,7 +279,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {
     "tags": []
    },
@@ -250,7 +301,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {
     "tags": []
    },
@@ -273,27 +324,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "ad3eeea8a1dc491b8f2a49b6249f6d71",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Button(description='Plot', style=ButtonStyle(), tooltip='Plot the data')"
-      ]
-     },
-     "execution_count": 13,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "def button_clicked(button):\n",
     "    output1.clear_output()\n",
@@ -340,27 +375,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "7b385ce9e53e4f69b9c46854e2a17275",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "TwoByTwoLayout(children=(Output(layout=Layout(grid_area='top-left')), Output(layout=Layout(grid_area='top-righ…"
-      ]
-     },
-     "execution_count": 14,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "widgets.TwoByTwoLayout(top_left=output1,\n",
     "                       top_right=output2,\n",
@@ -376,27 +395,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "fb0b01a1d9b24b44931573b8b1e6775e",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Output()"
-      ]
-     },
-     "execution_count": 15,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "output4"
    ]
@@ -425,7 +428,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.5"
+   "version": "3.10.9"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This fixes the issue with the sample data, all of the combinations should pass now without exceptions.
We should think if we want to just host our own xls so this doesn't take 10-20 seconds extra for the user to compose the dataset on start (vs having it ready and just download it from github).

Closes https://github.com/ploomber/cloud-backend/issues/259

@edublancas I wasn't sure how I can get rid of the success outputs, I tried minimizing the feedback: `SqlMagic.feedback=0` but it didn't work. Any ideas?