### PR TITLE
documenting usage of Ploomber Cloud for Chalk'it dashboards deployement

### DIFF
--- a/doc/_toc.yml
+++ b/doc/_toc.yml
@@ -26,6 +26,7 @@ parts:
       - file: apps/funix
       - file: apps/docker
       - file: apps/jupyterlab-plugin
+      - file: apps/chalk-it      
 
   - caption: Examples
     chapters:

--- a/doc/apps/chalk-it.md
+++ b/doc/apps/chalk-it.md
@@ -7,7 +7,7 @@ To deploy a [Chalk'it](https://github.com/ifpen/chalk-it) application in Ploombe
 
 ## `Dockerfile`
 
-You need to provide a `Dockerfile`, you can use this [template](https://github.com/ploomber/doc/blob/main/examples/docker/chalk-it/Dockerfile) to get started. The template contains the minimal steps needed for a deployment but you need to modify so it installs any required dependencies and copies your code into the Docker image.
+You just need to use this [template](https://github.com/ploomber/doc/blob/main/examples/docker/chalk-it/Dockerfile) `Dockerfile`:
 
 ```Dockerfile
 FROM python:3.11

--- a/doc/apps/chalk-it.md
+++ b/doc/apps/chalk-it.md
@@ -1,0 +1,46 @@
+# Chalk'it
+
+To deploy a [Chalk'it](https://github.com/ifpen/chalk-it) application in Ploomber Cloud you need:
+
+- A `Dockerfile`
+- A Chalk'it projet definition JSON file renamed to `dashboard.xprjson`
+
+## `Dockerfile`
+
+You need to provide a `Dockerfile`, you can use this [template](https://github.com/ploomber/doc/blob/main/examples/docker/chalk-it/Dockerfile) to get started. The template contains the minimal steps needed for a deployment but you need to modify so it installs any required dependencies and copies your code into the Docker image.
+
+```Dockerfile
+FROM python:3.11
+
+# assume your dashboard is named dashboard.xprjson
+COPY dashboard.xprjson dashboard.xprjson
+
+# install py-chalk-it and gunicorn
+RUN pip install py-chalk-it gunicorn
+
+# this configuration is needed for your app to work, do not change it
+ENTRYPOINT ["gunicorn", "chlkt.render:app", "run", "--bind", "0.0.0.0:80"]
+```
+
+## Testing locally
+
+To test your app, you can use `docker` locally:
+
+```sh
+# build the docker image
+docker build . -t dashboard
+
+# run it
+docker run -p 5000:80 dashboard
+```
+
+Now, open [http://0.0.0.0:5000/](http://0.0.0.0:5000/) to see your app.
+
+
+## Deploy
+
+Once you have all your files, create a zip file.
+
+To deploy a Chalk'it app from the deployment menu, follow these instructions:
+
+![](../static/docker.png)

--- a/examples/docker/chalk-it/Dockerfile
+++ b/examples/docker/chalk-it/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.11
+
+# assume your dashboard is named dashboard.xprjson
+COPY dashboard.xprjson dashboard.xprjson
+
+# install py-chalk-it and gunicorn
+RUN pip install py-chalk-it gunicorn
+
+# this configuration is needed for your app to work, do not change it
+ENTRYPOINT ["gunicorn", "chlkt.render:app", "run", "--bind", "0.0.0.0:80"]


### PR DESCRIPTION
Deployement of a Chalk'it projet into Plommber cloud documented.


<!-- readthedocs-preview ploomber-doc start -->
----
:books: Documentation preview :books:: https://ploomber-doc--49.org.readthedocs.build/en/49/

<!-- readthedocs-preview ploomber-doc end -->