### PR TITLE
Init From Existing Instructions

### DIFF
--- a/doc/user-guide/cli.md
+++ b/doc/user-guide/cli.md
@@ -36,18 +36,15 @@ The `deploy` command will print a URL that you can visit to track deployment pro
 
 ## Configure an existing project
 
-If you want to deploy an existing project, create a `ploomber-cloud.json` file in the root directory of your project with the following structure:
+If you want to deploy an existing project run the `init` command with the `--from-existing` flag:
 
-```json
-{
-    "id": "APP_ID",
-    "type": "APP_TYPE"
-}
+```sh
+ploomber-cloud init --from-existing
 ```
 
-Substitute `id` for your project ID and `type` for the app type (`docker`, `panel`, `streamlit`, etc.)
+This will prompt you to choose from a list of your existing projects.
 
-For example, if my app ID is `cool-tree-1860` and I'm deploying a `docker` app:
+Upon your choice, the command will generate a `ploomber-cloud.json` with your project's info. For example, if my app ID is `cool-tree-1860` and I'm deploying a `docker` app:
 
 
 ```json


### PR DESCRIPTION
- Edit `cli.md` to include instructions for `init --from-existing` under 'Configure an existing project'

<!-- readthedocs-preview ploomber-doc start -->
----
:books: Documentation preview :books:: https://ploomber-doc--53.org.readthedocs.build/en/53/

<!-- readthedocs-preview ploomber-doc end -->