### PR TITLE
Add instructions for secrets in CLI

### DIFF
--- a/doc/user-guide/cli.md
+++ b/doc/user-guide/cli.md
@@ -67,6 +67,7 @@ Then, execute:
 ploomber-cloud deploy
 ```
 
+(define-env-vars)=
 ## Defining environment variables
 
 If your project uses of environment variables, you can define them in an `.env` file.
@@ -87,4 +88,4 @@ ploomber-cloud deploy
 The command-line interface will automatically read and encrypt your environment variables and include them in the deployment.
 For security reasons, your `.env` file is replaced with an empty file at runtime. Ploomber only stores your encrypted environment variables.
 
-To learn how to read your environment variables from within your application, see [Reading variables.](./env-vars.md)
+To learn how to read your environment variables from within your application, see [Reading variables.](./env-vars.md#read-variables)

--- a/doc/user-guide/cli.md
+++ b/doc/user-guide/cli.md
@@ -89,4 +89,4 @@ ploomber-cloud deploy
 
 The command-line interface will automatically read your environment variables and include them in the deployment.
 
-Now, you can access and verify your environment variables inside your application. Learn how to access them [here.](./env-vars.md#-reading-variables)
+Now, you can access and verify your environment variables inside your application. Learn how to access them [here.](./env-vars.md)

--- a/doc/user-guide/cli.md
+++ b/doc/user-guide/cli.md
@@ -16,6 +16,7 @@ Then, set your API key ([learn how to get it](../quickstart/apikey.md)):
 ploomber-cloud key YOURKEY
 ```
 
+(init)=
 ## Initialize a new app
 
 If you want to create a new app, run the `init` command:
@@ -77,7 +78,7 @@ MY_ENV_VAR_1=value_1
 MY_ENV_VAR_2=value_2
 ```
 
-Now make sure your project has been [initialized](#-initialize-a-new-app), and deploy it:
+Now make sure your project has been [initialized](#init), and deploy it:
 
 ```sh
 ploomber-cloud deploy

--- a/doc/user-guide/cli.md
+++ b/doc/user-guide/cli.md
@@ -76,7 +76,7 @@ touch .env
 
 Then open `.env` in your code editor and enter your environment variables. It should look like this:
 
-```env
+```
 MY_ENV_VAR_1=value_1
 MY_ENV_VAR_2=value_2
 ```
@@ -89,4 +89,4 @@ ploomber-cloud deploy
 
 The command-line interface will automatically read your environment variables and include them in the deployment.
 
-Now, you can access your environment variables inside your application. Learn how to access them [here.](./env-vars.md#reading-variables)
+Now, you can access and verify your environment variables inside your application. Learn how to access them [here.](./env-vars.md#-reading-variables)

--- a/doc/user-guide/cli.md
+++ b/doc/user-guide/cli.md
@@ -65,3 +65,28 @@ Then, execute:
 ```sh
 ploomber-cloud deploy
 ```
+
+## Defining environment variables
+
+If your project makes use of environment variables, you can define them in an `.env` file. Simply run:
+
+```sh
+touch .env
+```
+
+Then open `.env` in your code editor and enter your environment variables. It should look like this:
+
+```env
+MY_ENV_VAR_1=value_1
+MY_ENV_VAR_2=value_2
+```
+
+Now make sure your project has been initialized, and deploy it:
+
+```sh
+ploomber-cloud deploy
+```
+
+The command-line interface will automatically read your environment variables and include them in the deployment.
+
+Now, you can access your environment variables inside your application. Learn how to access them [here.](./env-vars.md#reading-variables)

--- a/doc/user-guide/cli.md
+++ b/doc/user-guide/cli.md
@@ -69,7 +69,7 @@ ploomber-cloud deploy
 
 ## Defining environment variables
 
-If your project uses of environment variables, you can define them in an `.env` file.
+If your project uses environment variables, you can define them in an `.env` file.
 
 In your main project directory, create an `.env` file. Open it in your code editor, and enter your environment variables. It should look like this:
 

--- a/doc/user-guide/cli.md
+++ b/doc/user-guide/cli.md
@@ -70,14 +70,14 @@ ploomber-cloud deploy
 
 If your project uses of environment variables, you can define them in an `.env` file.
 
-Create an `.env` file, open in your code editor, and enter your environment variables. It should look like this:
+In your main project directory, create an `.env` file. Open it in your code editor, and enter your environment variables. It should look like this:
 
 ```
 MY_ENV_VAR_1=value_1
 MY_ENV_VAR_2=value_2
 ```
 
-Now make sure your project has been [initialized](#initialize-a-new-app), and deploy it:
+Now make sure your project has been [initialized](#-initialize-a-new-app), and deploy it:
 
 ```sh
 ploomber-cloud deploy

--- a/doc/user-guide/cli.md
+++ b/doc/user-guide/cli.md
@@ -68,25 +68,22 @@ ploomber-cloud deploy
 
 ## Defining environment variables
 
-If your project makes use of environment variables, you can define them in an `.env` file. Simply run:
+If your project uses of environment variables, you can define them in an `.env` file.
 
-```sh
-touch .env
-```
-
-Then open `.env` in your code editor and enter your environment variables. It should look like this:
+Create an `.env` file, open in your code editor, and enter your environment variables. It should look like this:
 
 ```
 MY_ENV_VAR_1=value_1
 MY_ENV_VAR_2=value_2
 ```
 
-Now make sure your project has been initialized, and deploy it:
+Now make sure your project has been [initialized](#initialize-a-new-app), and deploy it:
 
 ```sh
 ploomber-cloud deploy
 ```
 
-The command-line interface will automatically read your environment variables and include them in the deployment.
+The command-line interface will automatically read and encrypt your environment variables and include them in the deployment.
+For security reasons, your `.env` file is replaced with an empty file at runtime. Ploomber only stores your encrypted environment variables.
 
 To learn how to read your environment variables from within your application, see [Reading variables.](./env-vars.md)

--- a/doc/user-guide/cli.md
+++ b/doc/user-guide/cli.md
@@ -67,7 +67,6 @@ Then, execute:
 ploomber-cloud deploy
 ```
 
-(define-env-vars)=
 ## Defining environment variables
 
 If your project uses of environment variables, you can define them in an `.env` file.
@@ -88,4 +87,4 @@ ploomber-cloud deploy
 The command-line interface will automatically read and encrypt your environment variables and include them in the deployment.
 For security reasons, your `.env` file is replaced with an empty file at runtime. Ploomber only stores your encrypted environment variables.
 
-To learn how to read your environment variables from within your application, see [Reading variables.](./env-vars.md#read-variables)
+To learn how to read your environment variables from within your application, see [Reading variables.](./env-vars.md)

--- a/doc/user-guide/cli.md
+++ b/doc/user-guide/cli.md
@@ -89,4 +89,4 @@ ploomber-cloud deploy
 
 The command-line interface will automatically read your environment variables and include them in the deployment.
 
-Now, you can access and verify your environment variables inside your application. Learn how to access them [here.](./env-vars.md)
+To learn how to read your environment variables from within your application, see [Reading variables.](./env-vars.md)

--- a/doc/user-guide/env-vars.md
+++ b/doc/user-guide/env-vars.md
@@ -17,10 +17,9 @@ To add more, click on the button to the right:
 
 
 ```{tip}
-You can also define environment variables using the [command-line interface.](./cli.md#define-env-vars)
+You can also define environment variables using the [command-line interface.](./cli.md)
 ```
 
-(read-variables)=
 ## Reading variables
 
 To read the variables, use the following Python code:

--- a/doc/user-guide/env-vars.md
+++ b/doc/user-guide/env-vars.md
@@ -17,9 +17,10 @@ To add more, click on the button to the right:
 
 
 ```{tip}
-You can also define environment variables using the [command-line interface.](./cli.md)
+You can also define environment variables using the [command-line interface.](./cli.md#define-env-vars)
 ```
 
+(read-variables)=
 ## Reading variables
 
 To read the variables, use the following Python code:

--- a/doc/user-guide/env-vars.md
+++ b/doc/user-guide/env-vars.md
@@ -15,6 +15,11 @@ To add more, click on the button to the right:
 
 ![](../static/env-vars/env-vars-plus.png)
 
+
+```{Note}
+You can also define environment variables using the [command-line interface.](./cli.md#defining-environment-variables)
+```
+
 ## Reading variables
 
 To read the variables, use the following Python code:

--- a/doc/user-guide/env-vars.md
+++ b/doc/user-guide/env-vars.md
@@ -17,7 +17,7 @@ To add more, click on the button to the right:
 
 
 ```{Note}
-You can also define environment variables using the [command-line interface.](./cli.md#defining-environment-variables)
+You can also define environment variables using the [command-line interface.](./cli.md#-defining-environment-variables)
 ```
 
 ## Reading variables

--- a/doc/user-guide/env-vars.md
+++ b/doc/user-guide/env-vars.md
@@ -16,7 +16,7 @@ To add more, click on the button to the right:
 ![](../static/env-vars/env-vars-plus.png)
 
 
-```{Note}
+```{tip}
 You can also define environment variables using the [command-line interface.](./cli.md)
 ```
 

--- a/doc/user-guide/env-vars.md
+++ b/doc/user-guide/env-vars.md
@@ -17,7 +17,7 @@ To add more, click on the button to the right:
 
 
 ```{Note}
-You can also define environment variables using the [command-line interface.](./cli.md#-defining-environment-variables)
+You can also define environment variables using the [command-line interface.](./cli.md)
 ```
 
 ## Reading variables


### PR DESCRIPTION
- Added `Defining environment variables` section in `cli.md` to document support for secrets. Instructs users on how to configure secrets using `.env` file and deploy the project. Also links to `env_vars.md` for instructions on how to access and verify secrets from their application
- Added a note in `env_vars.md` that directs users to `cli.md` if they want to configure environment variables there

Related PR: https://github.com/ploomber/cli/pull/33

<!-- readthedocs-preview ploomber-doc start -->
----
📚 Documentation preview 📚: https://ploomber-doc--98.org.readthedocs.build/en/98/

<!-- readthedocs-preview ploomber-doc end -->