### PR TITLE
Typo: replace Panel with Streamlit in Streamlit deployment guide

### DIFF
--- a/doc/apps/streamlit.md
+++ b/doc/apps/streamlit.md
@@ -1,6 +1,6 @@
 # Streamlit
 
-Ploomber Cloud supports [Streamlit](https://streamlit.io/). For information on how to develop Panel apps, [please check the documentation](https://docs.streamlit.io/).
+Ploomber Cloud supports [Streamlit](https://streamlit.io/). For information on how to develop Streamlit apps, [please check the documentation](https://docs.streamlit.io/).
 
 To deploy a Streamlit app you need at least two files:
 


### PR DESCRIPTION
This PR fixes a minor typo in the guide about deploying Streamlit apps on Ploomber Cloud. The current guide names Panel but links to Streamlit's docs.

<!-- readthedocs-preview ploomber-doc start -->
----
📚 Documentation preview 📚: https://ploomber-doc--99.org.readthedocs.build/en/99/

<!-- readthedocs-preview ploomber-doc end -->