### PR TITLE
Rag news example fixes

### DIFF
--- a/examples/panel/rag-news/README.md
+++ b/examples/panel/rag-news/README.md
@@ -1,7 +1,16 @@
 # News summarizer
 
-To download today's news and compute the embeddings (needs OpenAI API key):
+To download today's news and compute the embeddings you first need to set the OpenAI key:
+
+```bash
+OPENAI_API_KEY=<your_api_key> 
+```
+
+Then run the below command to download the news:
 
 ```sh
 python rag_news.py
 ```
+
+Running the above command will generate a `embeddings.json` file and a `news` folder. Create a zip 
+from all the files and follow the instructions for deploying a [Panel](https://docs.cloud.ploomber.io/en/latest/apps/panel.html) application.

--- a/examples/panel/rag-news/README.md
+++ b/examples/panel/rag-news/README.md
@@ -14,3 +14,4 @@ python rag_news.py
 
 Running the above command will generate a `embeddings.json` file and a `news` folder. Create a zip 
 from all the files and follow the instructions for deploying a [Panel](https://docs.cloud.ploomber.io/en/latest/apps/panel.html) application.
+You also need to set `OPENAI_API_KEY` as an [environment variable](https://docs.cloud.ploomber.io/en/latest/user-guide/env-vars.html) while deploying the application.

--- a/examples/panel/rag-news/README.md
+++ b/examples/panel/rag-news/README.md
@@ -3,7 +3,7 @@
 To download today's news and compute the embeddings you first need to set the OpenAI key:
 
 ```bash
-OPENAI_API_KEY=<your_api_key> 
+export OPENAI_API_KEY=<your_api_key> 
 ```
 
 Then run the below command to download the news:

--- a/examples/panel/rag-news/rag_news.py
+++ b/examples/panel/rag-news/rag_news.py
@@ -48,8 +48,9 @@ class EmbeddingsStore:
         return len(self._data)
 
     def clear(self):
-        self._path.unlink()
-        self._data = {}
+        if self._path.exists():
+            self._path.unlink()
+            self._data = {}
 
 
 news_dir = Path("news")


### PR DESCRIPTION
1. Fixes error `FileNotFoundError: [Errno 2] No such file or directory: 'embeddings.json'` when downloading embeddings  for the first time.
2. Added more details to README.md.

Closes #123 

<!-- readthedocs-preview ploomber-doc start -->
----
📚 Documentation preview 📚: https://ploomber-doc--125.org.readthedocs.build/en/125/

<!-- readthedocs-preview ploomber-doc end -->