### PR TITLE
Update Dash documentation

### DIFF
--- a/doc/apps/dash.md
+++ b/doc/apps/dash.md
@@ -32,11 +32,58 @@ gunicorn app:server run --bind 0.0.0.0:5000
 
 Now, open [http://0.0.0.0:5000/](http://0.0.0.0:5000/) to see your app.
 
-
 ## Deploy
+
+`````{tab-set}
+
+````{tab-item} Web
+__Deploy from the menu__
 
 Once you have all your files, create a zip file.
 
 To deploy a Dash app from the deployment menu, select the Dash option and follow the instructions:
 
 ![](../static/dash.png)
+````
+
+````{tab-item} Command-line
+__Try an example__
+
+To download and deploy an example Dash application start by installing Ploomber Cloud and setting your API key:
+
+```sh
+pip install ploomber-cloud
+ploomber-cloud key YOUR-KEY
+```
+
+```{tip}
+If you don't have an API key yet, follow the [instructions here.](../quickstart/apikey.md)
+```
+
+Now, download an example. It will prompt you for a location to download the app. To download in the current directory, just press enter.
+
+```sh
+ploomber-cloud examples dash/clinical-analytics
+```
+
+```{note}
+A full list of Voila example apps is available [here.](https://github.com/ploomber/doc/tree/main/examples/dash)
+```
+
+You should see a confirmation with instructions on deploying your app. Now, navigate to your application:
+
+```sh
+cd location-you-entered/clinical-analytics
+```
+
+__Deploy from the CLI__
+
+Initialize and deploy your app with:
+
+```sh
+ploomber-cloud init
+ploomber-cloud deploy --watch
+```
+
+````
+`````

--- a/doc/apps/dash.md
+++ b/doc/apps/dash.md
@@ -67,7 +67,7 @@ ploomber-cloud examples dash/clinical-analytics
 ```
 
 ```{note}
-A full list of Voila example apps is available [here.](https://github.com/ploomber/doc/tree/main/examples/dash)
+A full list of Dash example apps is available [here.](https://github.com/ploomber/doc/tree/main/examples/dash)
 ```
 
 You should see a confirmation with instructions on deploying your app. Now, navigate to your application:

--- a/doc/user-guide/cli.md
+++ b/doc/user-guide/cli.md
@@ -1,7 +1,7 @@
 # Command-line interface
 
 ```{note}
-Currently, Voila deployments are unsupported by the CLI. Environment variables and authentication are also unsupported. Expect support to be added soon.
+Currently, authentication is unsupported by the CLI. Expect support to be added soon.
 ```
 
 You can deploy applications using the command-line interface. First, install the package:


### PR DESCRIPTION
- Now that Dash is supported natively, updated the deployment instructions to be similar to the other supported frameworks. Includes instructions on deploying an example from the CLI

- Also noticed that this note on the CLI page is not updated: 
![Screen Shot 2024-03-07 at 3 39 56 PM](https://github.com/ploomber/doc/assets/42661667/e958b95a-b714-45e3-a108-dd01ed3ea6f0)

Updated it since we now support Voila and environment variables.

<!-- readthedocs-preview ploomber-doc start -->
----
📚 Documentation preview 📚: https://ploomber-doc--141.org.readthedocs.build/en/141/

<!-- readthedocs-preview ploomber-doc end -->