### PR TITLE
Private ChatGPT Chainlit Example

### DIFF
--- a/examples/chainlit/private-chatgpt/Dockerfile
+++ b/examples/chainlit/private-chatgpt/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.11
+
+COPY app.py app.py
+COPY chainlit.md chainlit.md
+COPY requirements.txt requirements.txt
+RUN pip install -r requirements.txt
+
+# do not change the arguments
+ENTRYPOINT ["chainlit", "run", "app.py", "--host=0.0.0.0", "--port=80", "--headless"]

--- a/examples/chainlit/private-chatgpt/README.md
+++ b/examples/chainlit/private-chatgpt/README.md
@@ -9,7 +9,7 @@ Ensure your LLM has already been deployed.
 If you configured a private API key on the backend, set it here via a secret or `.env` file:
 
 ```sh
-export VLLM_KEY=your_key
+export VLLM_API_KEY=your_key
 ```
 
 Note down the host URL. In `app.py`, modify `api_base` with your host URL.

--- a/examples/chainlit/private-chatgpt/README.md
+++ b/examples/chainlit/private-chatgpt/README.md
@@ -1,0 +1,22 @@
+# Private ChatGPT
+
+A basic Chainlit chat UI to be used with an LLM hosted and served via vLLM.
+
+## Deployment instructions:
+
+Ensure your LLM has already been deployed.
+
+If you configured a private API key on the backend, set it here via a secret or `.env` file:
+
+```sh
+export VLLM_KEY=your_key
+```
+
+Note down the host URL. In `app.py`, modify `api_base` with your host URL.
+
+Then, initialize and deploy:
+
+```sh
+ploomber-cloud init
+ploomber-cloud deploy --watch
+```

--- a/examples/chainlit/private-chatgpt/app.py
+++ b/examples/chainlit/private-chatgpt/app.py
@@ -1,0 +1,50 @@
+from openai import AsyncOpenAI
+import chainlit as cl
+import os
+
+# Enter the personal API key that you set for the host, 
+# or leave it blank if you didn't set one
+vllm_key = os.environ.get("VLLM_KEY") or ""
+
+# Modify this value to match your host, remember to add /v1 at the end
+api_base = "https://aged-math-3623.ploomberapp.io/v1"
+
+client = AsyncOpenAI(
+    api_key=vllm_key,
+    base_url=api_base,
+)
+
+# Instrument the OpenAI client
+cl.instrument_openai()
+
+settings = {
+    "model": "google/gemma-2b-it",
+    # ... more settings
+}
+
+messages = []
+
+@cl.on_chat_start
+def main():
+    messages = []
+    cl.user_session.set("messages", messages)
+
+@cl.on_message
+async def on_message(message: cl.Message):
+    messages = cl.user_session.get("messages")
+    messages = messages + [
+        {
+            "content": message.content,
+            "role": "user"
+        }
+    ]
+    response = await client.chat.completions.create(
+        messages=messages,
+        **settings
+    )
+    messages = messages + [{
+        "content": response.choices[0].message.content,
+        "role": "assistant",
+    }]
+    cl.user_session.set("messages", messages)
+    await cl.Message(content=response.choices[0].message.content).send()

--- a/examples/chainlit/private-chatgpt/app.py
+++ b/examples/chainlit/private-chatgpt/app.py
@@ -4,7 +4,7 @@ import os
 
 # Enter the personal API key that you set for the host, 
 # or leave it blank if you didn't set one
-vllm_key = os.environ.get("VLLM_KEY") or ""
+vllm_key = os.environ.get("VLLM_API_KEY") or ""
 
 # Modify this value to match your host, remember to add /v1 at the end
 api_base = "https://aged-math-3623.ploomberapp.io/v1"

--- a/examples/chainlit/private-chatgpt/chainlit.md
+++ b/examples/chainlit/private-chatgpt/chainlit.md
@@ -1,0 +1,5 @@
+# Custom ChatGPT with vLLM 🚀🤖
+
+This application is a custom ChatGPT that uses vLLM + gemma-2b-it and Chainlit for the chat interface.
+
+Deploy your own version using __Ploomber Cloud!__

--- a/examples/chainlit/private-chatgpt/requirements.txt
+++ b/examples/chainlit/private-chatgpt/requirements.txt
@@ -1,0 +1,2 @@
+chainlit
+openai


### PR DESCRIPTION
- Added `examples/chainlit/private-chatgpt` which is the Chainlit UI for this blog post:

https://github.com/ploomber/ploomber.io/pull/154

<!-- readthedocs-preview ploomber-doc start -->
----
📚 Documentation preview 📚: https://ploomber-doc--176.org.readthedocs.build/en/176/

<!-- readthedocs-preview ploomber-doc end -->