### PR TITLE
Document `ploomber-cloud resources`

### DIFF
--- a/doc/user-guide/cli.md
+++ b/doc/user-guide/cli.md
@@ -208,3 +208,33 @@ The command-line interface will automatically read and encrypt your secrets and 
 For security reasons, your `.env` file is replaced with an empty file at runtime. Ploomber only stores your encrypted secrets.
 
 To learn how to read your secrets from within your application, see [Reading secrets.](./secrets.md)
+
+
+## Configure resources
+
+You can customize the amount of `CPUs`, `RAM`, and `GPUs` that your project will use with this command:
+
+```sh
+ploomber-cloud resources
+```
+
+If your `ploomber-cloud.json` file already has a `resources` section, you can reconfigure with the `--force` flag:
+
+```sh
+ploomber-cloud resources --force
+```
+
+### Carrying over resources
+
+When you initialize a project using `--force` or `--from-existing`, your resources are carried over.
+
+`ploomber-cloud init --force` will carry over the resources from the `ploomber-cloud.json` file.
+
+`ploomber-cloud init --from-existing` and `ploomber-cloud init --from-existing --force` will carry over the resources that the project was most recently deployed with.
+
+If you run any of these commands, be sure to double check your resources by checking the `ploomber-cloud.json` or running `ploomber-cloud resources`.
+You can easily reconfigure them with:
+
+```sh
+ploomber-cloud resources --force
+```

--- a/doc/user-guide/gpu.md
+++ b/doc/user-guide/gpu.md
@@ -40,3 +40,30 @@ Then, in the deployment form, select `1 GPU` in the `Advanced` section:
 
 Currently, only `1 GPU` is supported, which will deploy your application on a
 machine with an NVIDIA T4 (16GB), 4 CPUs and 16 GB of RAM.
+
+## Using the CLI
+
+You can also deploy your project with a GPU using the command-line interface. Set your API key and initialize your project:
+
+```sh
+ploomber-cloud key YOURKEY
+ploomber-cloud init
+```
+
+Now, configure your resources:
+
+```sh
+ploomber-cloud resources
+```
+
+When you select `1 GPU`, CPU and RAM are fixed at `4 CPUs` and `16 GB RAM`.
+
+Finally deploy your project:
+
+```sh
+ploomber-cloud deploy --watch
+```
+
+For more info on configuring resources in the CLI, [click here](../user-guide/cli.md#configure-resources)
+
+

--- a/doc/user-guide/resources.md
+++ b/doc/user-guide/resources.md
@@ -17,3 +17,13 @@ If you want to increase or reduce the resources provisioned for an existing appl
 ![](../static/resources/redeploy.png)
 
 You'll need to provide the source code again. In the last section, you'll be able to choose the resources to provision.
+
+## Configure via the CLI
+
+To configure resources via the command-line interface simply run:
+
+```sh
+ploomber-cloud resources
+```
+
+For more info on configuring resources in the CLI, [click here](../user-guide/cli.md#configure-resources)

--- a/doc/user-guide/resources.md
+++ b/doc/user-guide/resources.md
@@ -33,6 +33,8 @@ Then simply run:
 ploomber-cloud resources
 ```
 
+You'll be prompted to select number of `GPUs`, `CPUs` and `RAM`.
+
 Finally deploy your project and see that your resources have been customized:
 
 ```sh

--- a/doc/user-guide/resources.md
+++ b/doc/user-guide/resources.md
@@ -20,10 +20,23 @@ You'll need to provide the source code again. In the last section, you'll be abl
 
 ## Configure via the CLI
 
-To configure resources via the command-line interface simply run:
+To configure resources via the command-line interface, first set your API key and initialize your project:
+
+```sh
+ploomber-cloud key YOURKEY
+ploomber-cloud init
+```
+
+Then simply run:
 
 ```sh
 ploomber-cloud resources
+```
+
+Finally deploy your project and see that your resources have been customized:
+
+```sh
+ploomber-cloud deploy --watch
 ```
 
 For more info on configuring resources in the CLI, [click here](../user-guide/cli.md#configure-resources)


### PR DESCRIPTION
- Added documentation for `ploomber-cloud resources` under `cli.md`, `resources.md`, and `gpu.md`

See this PR: https://github.com/ploomber/cli/pull/83

<!-- readthedocs-preview ploomber-doc start -->
----
📚 Documentation preview 📚: https://ploomber-doc--203.org.readthedocs.build/en/203/

<!-- readthedocs-preview ploomber-doc end -->