### PR TITLE
adds `--config/-c` doc

### DIFF
--- a/doc/user-guide/cli.md
+++ b/doc/user-guide/cli.md
@@ -335,3 +335,17 @@ To view all labels added to your project simply run:
 ```sh 
 ploomber-cloud labels
 ```
+
+## Switching the configuration file
+
+By default, the CLI reads and writes to a `ploomber-cloud.json` file, but you can customize it via the `--config` (or its short version, `-c`), switching the config file is useful when you need to manage multiple environments (for example, development and production).
+
+All commands that read or write the config file accept the `--config/-c` argument, for example:
+
+```sh
+# create the config file in ploomber-cloud.dev.json
+ploomber-cloud init --config ploomber-cloud.dev.json
+
+# deploy using the dev config
+ploomber-cloud deploy --config ploomber-cloud.dev.json
+```


### PR DESCRIPTION

docs for this: https://github.com/ploomber/cli/pull/101

<!-- readthedocs-preview ploomber-doc start -->
----
📚 Documentation preview 📚: https://ploomber-doc--215.org.readthedocs.build/en/215/

<!-- readthedocs-preview ploomber-doc end -->