### PR TITLE
Doc for ignore section in ploomber-cloud.json

### DIFF
--- a/doc/user-guide/cli.md
+++ b/doc/user-guide/cli.md
@@ -98,6 +98,21 @@ It can also be combined with the `--from-existing` for re-initializing from an e
 ploomber-cloud init --from-existing --force
 ```
 
+## Ignore a file or directory
+
+You can choose to ignore any file or directory by adding a list in the `ignore` field in `ploomber-cloud.json`. Example:
+
+```json
+{
+    "id": "cool-tree-1860",
+    "type": "docker",
+    "ignore": [
+        "ignore.txt",
+        "ignore_dir"
+    ]
+}
+```
+
 ## Delete an app
 
 For deleting a particular app run the `delete` command with the `--project-id` flag:

--- a/doc/user-guide/cli.md
+++ b/doc/user-guide/cli.md
@@ -100,7 +100,12 @@ ploomber-cloud init --from-existing --force
 
 ## Ignore a file or directory
 
-You can choose to ignore any file or directory by adding a list in the `ignore` field in `ploomber-cloud.json`. Example:
+You can choose to ignore any file or directory by adding a list in the `ignore` field in `ploomber-cloud.json`. These files will not be included in the uploaded zip file. Format of ignored files or directories:
+- `name`: all files or folders with `name`
+- `dir/`: all files or folders in folder with name `dir`
+- `dir/file` and `dir/dir/`: all files/folders with the specified path relative to root
+
+Example:
 
 ```json
 {
@@ -108,7 +113,8 @@ You can choose to ignore any file or directory by adding a list in the `ignore` 
     "type": "docker",
     "ignore": [
         "ignore.txt",
-        "ignore_dir"
+        "ignore_dir/",
+        "dir/ignore2.txt"
     ]
 }
 ```


### PR DESCRIPTION
- Added documentation supporting user custom ignore in ploomber-cloud.json

Closes [ploomber/cli#45](https://github.com/ploomber/cli/issues/45)

<!-- readthedocs-preview ploomber-doc start -->
----
📚 Documentation preview 📚: https://ploomber-doc--256.org.readthedocs.build/en/256/

<!-- readthedocs-preview ploomber-doc end -->