### PR TITLE
[Bug] Outdated dependencies in example

### DIFF
--- a/examples/panel/weights-and-biases-llm/requirements.txt
+++ b/examples/panel/weights-and-biases-llm/requirements.txt
@@ -2,4 +2,5 @@ openai==1.12.0
 panel==1.3.8
 ploomber-cloud
 wandb==0.16.3
+numpy==1.26.4
 ipython

--- a/examples/streamlit/mirascope-url-extractor/app.py
+++ b/examples/streamlit/mirascope-url-extractor/app.py
@@ -3,8 +3,8 @@ from typing import Dict, List, Literal, Optional, Type, Union
 from urllib.request import Request, urlopen
 
 from bs4 import BeautifulSoup
-from mirascope.anthropic import AnthropicExtractor, AnthropicCallParams
 from mirascope.base.tools import DEFAULT_TOOL_DOCSTRING
+from mirascope.anthropic  import AnthropicExtractor, AnthropicCallParams
 from pydantic import BaseModel, Field, computed_field, create_model
 import streamlit as st
 

--- a/examples/streamlit/mirascope-url-extractor/requirements.txt
+++ b/examples/streamlit/mirascope-url-extractor/requirements.txt
@@ -1,4 +1,5 @@
-mirascope[anthropic]>=0.9.0
-streamlit
-pydantic-settings
-beautifulsoup4
+mirascope[anthropic]==0.9.1
+streamlit==1.33.0
+pydantic-settings==2.2.1
+beautifulsoup4==4.12.3
+anthropic==0.23.1

--- a/examples/voila/mosaic/requirements.txt
+++ b/examples/voila/mosaic/requirements.txt
@@ -1,6 +1,10 @@
 # requirements for mosaic example
-pandas<2
-mosaic_widget
-jupysql
-duckdb-engine
-voila
+mosaic-widget==0.5.0
+jupysql==0.10.10
+duckdb_engine==0.11.2
+numpy==1.26.4
+pandas==1.5.3
+voila==0.5.5
+ipython==8.22.2
+ipykernel==6.29.3
+jupyter


### PR DESCRIPTION
While testing some example apps to test https://github.com/ploomber/cloud-frontend/pull/601, the following three were having runtime errors due to the fact that the newer versions of the dependencies used are not backward compatible.

<!-- readthedocs-preview ploomber-doc start -->
----
📚 Documentation preview 📚: https://ploomber-doc--285.org.readthedocs.build/en/285/

<!-- readthedocs-preview ploomber-doc end -->