### PR TITLE
[Bug] Docker is available on all tier

### DIFF
--- a/doc/faq/faq.md
+++ b/doc/faq/faq.md
@@ -117,6 +117,6 @@ Here's a few additional features that `Docker` deployment allows:
 * Customizing the Docker base image.
 * Adding a cache layer
 
-To unlock `Docker` deployment, [upgrade to Pro.](https://ploomber.io/pricing/)
+[Upgrade your plan](https://ploomber.io/pricing/) to unlock advanced features like password protection, analytics and many more capabilities.
 
-[Click here](../pricing/overview.md) to see all Pro, Teams, and Enterprise features.
+[Click here](../pricing/overview.md) to see all Pro, Team, and Enterprise features.

--- a/doc/faq/faq.md
+++ b/doc/faq/faq.md
@@ -119,4 +119,4 @@ Here's a few additional features that `Docker` deployment allows:
 
 [Upgrade your plan](https://ploomber.io/pricing/) to unlock advanced features like password protection, analytics and many more capabilities.
 
-[Click here](../pricing/overview.md) to see all Pro, Team, and Enterprise features.
+[Click here](../pricing/overview.md) to see all Pro, Teams, and Enterprise features.

--- a/doc/pricing/overview.md
+++ b/doc/pricing/overview.md
@@ -29,7 +29,6 @@
 - App password protection
 - Faster app builds
 - Deployment artifact limited to 200MB
-- Deploy Docker apps
 - Email and Slack support
 
 ### Teams


### PR DESCRIPTION
While reading the doc, I saw that there were still some artefact that docker is Pro only

<!-- readthedocs-preview ploomber-doc start -->
----
📚 Documentation preview 📚: https://ploomber-doc--288.org.readthedocs.build/en/288/

<!-- readthedocs-preview ploomber-doc end -->