### PR TITLE
[Bug] Deprecated stremalit api for Auth0 example

### DIFF
--- a/examples/streamlit/app-with-auth0/app.py
+++ b/examples/streamlit/app-with-auth0/app.py
@@ -1,7 +1,7 @@
 import streamlit as st
 from streamlit.web.server.websocket_headers import _get_websocket_headers
 
-headers = _get_websocket_headers()
+headers = st.context.headers
 
 
 header_name = headers.get("X-Auth-Name")

--- a/examples/streamlit/app-with-auth0/readme.md
+++ b/examples/streamlit/app-with-auth0/readme.md
@@ -1,0 +1,13 @@
+# Authentication
+
+Our seamless integration with Auth0 enables you to add robust authentication to any Streamlit app effortlessly. There's no need to modify your existing Streamlit app code!
+
+## User Information Retrieval
+
+If you need to access user information returned by Auth0, this repository provides a practical example demonstrating how to do so.
+
+## Learn More
+
+For more information about authentication in Ploomber Cloud, including setup instructions, please refer to our official documentation:
+
+[Ploomber Cloud - Streamlit Authentication Documentation](https://docs.cloud.ploomber.io/en/latest/apps/streamlit.html#authentication)


### PR DESCRIPTION
- Updated the depreciated code
- I also added a `readme.md`, because if someone look at it without coming from the docs, this one will have no idea on how to get started

closes #299 

<!-- readthedocs-preview ploomber-doc start -->
----
📚 Documentation preview 📚: https://ploomber-doc--300.org.readthedocs.build/en/300/

<!-- readthedocs-preview ploomber-doc end -->