### PR TITLE
[Doc] Mention multiple domain possible `ploomber.app` & `ploomberapp.io`

### DIFF
--- a/doc/apps/dash.md
+++ b/doc/apps/dash.md
@@ -164,8 +164,6 @@ By default applications run with Python 3.11. Refer to this [section](../faq/faq
 
 :::{grid-item-card} Clinical analytics
 [![](../../examples/dash/clinical-analytics/screenshot.webp)](https://github.com/ploomber/doc/tree/main/examples/dash/clinical-analytics)
-+++
-[Live demo](https://delicate-cake-9107.ploomberapp.io)
 :::
 
 ::::

--- a/doc/apps/flask.md
+++ b/doc/apps/flask.md
@@ -133,8 +133,6 @@ A basic Flask app.
 
 :::{grid-item-card} User auth
 [![](../../examples/flask/login/screenshot.webp)](https://github.com/ploomber/doc/tree/main/examples/flask/login)
-+++
-[Live demo](https://empty-haze-3369.ploomberapp.io)
 :::
 
 :::{grid-item-card} ML inference

--- a/doc/apps/jupyterlab.md
+++ b/doc/apps/jupyterlab.md
@@ -87,7 +87,7 @@ And you're ready to use JupyterLab!
 
 ## Real-time collaboration
 
-Collaboration is configured by default! Share your `id.ploomberapp.io` URL with a colleague, the password, and open the same notebook, you'll get Google Doc-like collaboration!
+Collaboration is configured by default! Share your URL with a colleague (it'll be using either `id.ploomber.app` or `id.ploomberapp.io`), the password, and open the same notebook, you'll get Google Doc-like collaboration!
 
 
 ![](../static/docker/jupyterlab/jupyter-collab.gif)
@@ -122,7 +122,7 @@ python -c 'import secrets; print(secrets.token_urlsafe())'
 Copy the printed value (store it somewhere safe) and save it as a [secret](../user-guide/secrets.md), with
 the name `KG_AUTH_TOKEN`, now click on `CREATE`.
 
-Once the application is running, copy the URL (the `someid.ploomberapp.io` URL):
+Once the application is running, copy the URL (either `someid.ploomber.app` or `someid.ploomberapp.io`):
 
 ![](../static/docker/mlflow/host.png)
 
@@ -132,10 +132,10 @@ We can connect to the remote kernel. Install JupyterLab locally:
 pip install jupyterlab
 ```
 
-And initialize it with your `someid.ploomberapp.io` URL and the token you set earlier:
+And initialize it with your either `someid.ploomber.app` or `someid.ploomberapp.io` URL and the token you set earlier:
 
 ```sh
-GATEWAY_HOST=someid.ploomberapp.io
+GATEWAY_HOST=someid.ploomberapp.io # Should match your app domain (ploomber.app OR ploomberapp.io)
 TOKEN=sometoken
 jupyter lab --gateway-url=$GATEWAY_HOST --GatewayClient.auth_token=$TOKEN
 ```

--- a/doc/apps/mlflow.md
+++ b/doc/apps/mlflow.md
@@ -91,7 +91,10 @@ And run the following in a Python session:
 import requests
 from getpass import getpass
 
-host = input("Enter your {id}.ploomberapp.io URL: ")
+# Notes:
+# - We're gradually migrating from id.ploomberapp.io to id.ploomber.app
+# - Modify this value to match your host
+host = input("Enter your {id}.ploomberapp.io URL: ") 
 password_new = getpass("Enter new password:")
 
 response = requests.patch(
@@ -105,7 +108,7 @@ response.raise_for_status()
 print("Your new password is:", password_new)
 ```
 
-You'll be prompted for your MLflow host (e.g., `something.ploomberapp.io`), you can
+You'll be prompted for your MLflow host (e.g., either `id.ploomber.app` or `id.ploomberapp.io`), you can
 get this from the Ploomber UI:
 
 ![](../static/docker/mlflow/host.png)
@@ -134,6 +137,10 @@ And run the following (replace the `set_tracking_uri` call with your host!):
 
 ```python
 import mlflow
+
+# Notes:
+# - We're gradually migrating from id.ploomberapp.io to id.ploomber.app
+# - Modify this value to match your host
 mlflow.set_tracking_uri(uri="https://someid.ploomberapp.io")
 
 mlflow.set_experiment("first-experiment")

--- a/doc/apps/panel.md
+++ b/doc/apps/panel.md
@@ -151,8 +151,6 @@ By default applications run with Python 3.11. Refer to this [section](../faq/faq
 
 :::{grid-item-card} Book recommender
 [![](../../examples/panel/book-recommender/screenshot.webp)](https://github.com/ploomber/doc/tree/main/examples/panel/book-recommender)
-+++
-[Live demo](https://gentle-frost-8296.ploomberapp.io)
 :::
 
 :::{grid-item-card} Chat with PDF
@@ -167,8 +165,6 @@ By default applications run with Python 3.11. Refer to this [section](../faq/faq
 
 :::{grid-item-card} Customer Chatbot
 [![](../../examples/panel/customer-chatbot/screenshot.webp)](https://github.com/ploomber/doc/tree/main/examples/panel/customer-chatbot)
-+++
-[Live demo](https://black-poetry-5215.ploomberapp.io)
 :::
 
 :::{grid-item-card} Multi Page App
@@ -178,8 +174,6 @@ By default applications run with Python 3.11. Refer to this [section](../faq/faq
 :::{grid-item-card} Wine Data Postgres App
 :link: https://github.com/ploomber/doc/tree/main/examples/panel/app-with-postgres
 ![](https://github.com/ploomber/doc/raw/main/examples/panel/app-with-postgres/app.png)
-+++
-[Live demo](https://panel-postgres-demo.ploomberapp.io/app)
 :::
 
 ::::

--- a/doc/apps/vllm.md
+++ b/doc/apps/vllm.md
@@ -143,7 +143,9 @@ from openai import OpenAI
 # we haven't configured authentication, so we just pass a dummy value
 openai_api_key = "PUT_YOUR_API_KEY_HERE"
 
-# modify this value to match your host, remember to add /v1 at the end
+# Notes:
+# - We're gradually migrating from id.ploomberapp.io to id.ploomber.app
+# - Modify this value to match your host, remember to add /v1 at the end
 openai_api_base = "https://autumn-snow-1380.ploomberapp.io/v1"
 
 client = OpenAI(

--- a/doc/intro.md
+++ b/doc/intro.md
@@ -115,20 +115,14 @@ Ploomber Cloud allows you to easily deploy apps. **Select a framework** to learn
 
 :::{grid-item-card} Chatbots
 [![](../examples/panel/book-recommender/screenshot.webp)](https://github.com/ploomber/doc/tree/main/examples/panel/book-recommender)
-+++
-[Live demo](https://gentle-frost-8296.ploomberapp.io)
 :::
 
 :::{grid-item-card} Analytical dashboards
 [![](../examples/dash/clinical-analytics/screenshot.webp)](https://github.com/ploomber/doc/tree/main/examples/dash/clinical-analytics)
-+++
-[Live demo](https://delicate-cake-9107.ploomberapp.io)
 :::
 
 :::{grid-item-card} REST API
 [![](../examples/flask/login/screenshot.webp)](https://github.com/ploomber/doc/tree/main/examples/flask/login)
-+++
-[Live demo](https://empty-haze-3369.ploomberapp.io)
 :::
 
 :::{grid-item-card} Machine Learning inference

--- a/doc/user-guide/cli.md
+++ b/doc/user-guide/cli.md
@@ -472,6 +472,6 @@ ploomber-cloud stop --project-id PROJECT_ID
 ```
 
 Where `PROJECT_ID` is the randomly generated ID. If you did not set a custom name,
-the `PROJECT_ID` is the string in the URL (`PROJECT_ID.ploomberapp.io`), if you set
+the `PROJECT_ID` is the string in the URL (either `PROJECT_ID.ploomber.app` or `PROJECT_ID.ploomberapp.io`), if you set
 a custom name, you can retrieve the `PROJECT_ID` by clicking on the ⚙️ icon next to the
 URL in your app detailed view.

--- a/doc/user-guide/custom-domains.md
+++ b/doc/user-guide/custom-domains.md
@@ -4,14 +4,18 @@
 Custom domains/subdomains are only available to customers in the Pro, Teams and Enterprise plans.
 ```
 
-By default, applications are available under `project-id.ploomberapp.io`, where `project-id` is a randomly generated string.
+Each application gets a unique URL in the format `project-id.ploomber.app` or `project-id.ploomberapp.io`, where project-id is an automatically generated identifier.
+
+```{important}
+We are slowly migrating all new applications to `ploomber.app`, but some existing apps are still on `ploomberapp.io`.
+```
 
 You can customize the [`project-id`](custom-ploomber-subdomain) or bring your [own domain](custom-domain) or [custom subdomain](custom-subdomain).
 
 (custom-ploomber-subdomain)=
-## `{custom}.ploomberapp.io`
+## `{custom}.ploomber.app` and `{custom}.ploomberapp.io`
 
-If you would like a custom `ploomberapp.io` subdomain, like `my-custom-app.ploomberapp.io`, you can add it during application setup:
+If you would like a custom `ploomberapp.io` or `ploomber.app` subdomain, like `my-custom-app.ploomberapp.io`, you can add it during application setup:
 
 ![](../static/custom-domains/custom-names.png)
 
@@ -40,11 +44,14 @@ A new window will display showing the DNS records you need to add ([see the upda
 
 ![](../static/custom-domains/pointing-change-dns-records.png)
 
+```{important}
+We are slowly migrating all new applications to `ploomber.app`, but some existing apps are still on `ploomberapp.io`. Make sure your DNS records match the domain associated with your application.
+```
 
 You must add three DNS records:
 
-1. A `ALIAS` record: `@` as host, and `yourapp.ploomberapp.io` as value (replace `yourapp` with your actual app ID)
-2. A `CNAME` record: `www` as host, and `yourapp.ploomberapp.io` as value (replace `yourapp` with your actual app ID)
+1. A `ALIAS` record: `@` as host, and `yourapp.ploomberapp.io` (or `yourapp.ploomber.app`) as value (replace `yourapp` with your actual app ID)
+2. A `CNAME` record: `www` as host, and `yourapp.ploomberapp.io` (or `yourapp.ploomber.app`) as value (replace `yourapp` with your actual app ID)
 3. A `CNAME` record: with the shown **CNAME name** and **CNAME value** (as displayed in the **SSL certification status** section)
 
 ```{important}
@@ -103,7 +110,7 @@ A new window will display showing the DNS records you need to add ([see the upda
 
 You must add two records:
 
-1. `CNAME` record: the subdomain you want to add as the host (e.g., if you want to connect `subdomain.yourdomain.com`, then, you must enter `subdomain`) and `yourapp.ploomberapp.io` as value (where `yourapp` is the ID assigned to your application)
+1. `CNAME` record: the subdomain you want to add as the host (e.g., if you want to connect `subdomain.yourdomain.com`, then, you must enter `subdomain`) and `yourapp.ploomberapp.io` (or `yourapp.ploomber.app` dependending on your application domain) as value (where `yourapp` is the ID assigned to your application)
 2. `CNAME` record: with the shown **CNAME name** and **CNAME value** (as displayed in the **SSL certification status** section)
 
 
@@ -143,7 +150,7 @@ if you encounter errors, remove the root domain from the value. (see this
 
 
 ```{important}
-DNS record changes might take up to 48 hours to take effect. In the meantime, your application will be accessible from the `ploomberapp.io` URL
+DNS record changes might take up to 48 hours to take effect. In the meantime, your application will be accessible from the `ploomber.app` or `ploomberapp.io` URL
 ```
 
 ## Moving an existing domain/subdomain to another app
@@ -190,7 +197,7 @@ These are the most common errors.
 
 ![](../static/custom-domains/domains-server-not-found.png)
 
-You'll see this error if you're missing the DNAME record that points from your domain (or subdomain) to the `ID.ploomberapp.io` URL, ensure you add it. Give it some time since DNS records take some time to update. If issues persist, contact us at [contact@ploomber.io](mailto:contact@ploomber.io).
+You'll see this error if you're missing the DNAME record that points from your domain (or subdomain) to the  `ID.ploomber.app` or `ID.ploomberapp.io` URL (depending on your application domain), ensure you add it. Give it some time since DNS records take some time to update. If issues persist, contact us at [contact@ploomber.io](mailto:contact@ploomber.io).
 
 
 ### Potential Security Risk Ahead

--- a/doc/user-guide/custom-domains.md
+++ b/doc/user-guide/custom-domains.md
@@ -15,7 +15,7 @@ You can customize the [`project-id`](custom-ploomber-subdomain) or bring your [o
 (custom-ploomber-subdomain)=
 ## `{custom}.ploomber.app` and `{custom}.ploomberapp.io`
 
-If you would like a custom `ploomberapp.io` or `ploomber.app` subdomain, like `my-custom-app.ploomberapp.io`, you can add it during application setup:
+If you would like a custom `ploomber.app` or `ploomberapp.io` subdomain, like `my-custom-app.ploomberapp.io`, you can add it during application setup:
 
 ![](../static/custom-domains/custom-names.png)
 

--- a/doc/user-guide/password.md
+++ b/doc/user-guide/password.md
@@ -161,12 +161,16 @@ edit it by updating the `.env` file. This secret is used to sign your session to
 (auth0-urls)=
 ### Set `/callback` and `/status` URLs
 
-Almost done! We just need to set the `/callback` and `/status` URLs for your Auth0 app. Navigate to your Ploomber project's application page and copy the application URL. It should look like `https://application-name-1999.ploomberapp.io`.
+Almost done! We just need to set the `/callback` and `/status` URLs for your Auth0 app. Navigate to your Ploomber project's application page and copy the application URL. It should look like `https://application-name-1999.ploomber.app` or `https://application-name-1999.ploomberapp.io` (depending on your application domain).
 
 Now, go back to the Auth0 application page and scroll down to `Application URIs`. Set these values:
 
-- Allowed Callback URLs: `https://application-name-1999.ploomberapp.io/callback`
-- Allows Logout URLs: `https://application-name-1999.ploomberapp.io/status`
+- Allowed Callback URLs: `https://application-name-1999.ploomber.app/callback` 
+- Allows Logout URLs: `https://application-name-1999.ploomber.app/status`
+
+```{important}
+We are slowly migrating all new applications to `ploomber.app`, but some existing apps are still on `ploomberapp.io`. Make sure your URLs match the domain associated with your application.
+```
 
 It should look like this:
 


### PR DESCRIPTION
- **BUG FIX** Remove the link in the demo to application that doesn't exist anymore
- **DOC** Mention that we are slowly migrating to `ploomber.app` where `ploomberapp.io` is mentionned

closes: https://github.com/ploomber/doc/issues/301

<!-- readthedocs-preview ploomber-doc start -->
----
📚 Documentation preview 📚: https://ploomber-doc--303.org.readthedocs.build/en/303/

<!-- readthedocs-preview ploomber-doc end -->