### PR TITLE
[Bug] Remove dead code in example

### DIFF
--- a/examples/streamlit/app-with-auth0/app.py
+++ b/examples/streamlit/app-with-auth0/app.py
@@ -1,5 +1,4 @@
 import streamlit as st
-from streamlit.web.server.websocket_headers import _get_websocket_headers
 
 headers = st.context.headers
 


### PR DESCRIPTION
> **ISSUE**
> I saw this on a streamlit app:
> 
> The _get_websocket_headers function is deprecated and will be removed in a future version of >Streamlit. Please use st.context.headers instead
> 
> we need to update our docs and example apps



We already updated all occurrences, but we forgot the close the issue.
```
e9efb33f ◯ [Bug] Deprecated stremalit api for Auth0 example (#300)
```
The match was because the import wasn't deleted.


closes: https://github.com/ploomber/doc/issues/277