### PR TITLE
CLI `include` option documentation

### DIFF
--- a/doc/user-guide/cli.md
+++ b/doc/user-guide/cli.md
@@ -552,3 +552,34 @@ To start Dev Mode, run from your project folder:
 ```sh
 ploomber-cloud dev
 ```
+
+## Explicitly include files
+
+```{versionadded} 0.4.5
+```
+
+By default, `ploomber-cloud` ignores certain files when deploying your app (e.g. `.git` or `.pyc`).
+
+If you want to make sure certain files are **not** ignored, you can specify them in the `include` config field.
+
+You'll need to generate your config file using:
+
+```sh
+ploomber-cloud init
+```
+
+Next, add the `include` field to the generated `ploomber-cloud.json`:
+
+```json
+{
+    "id": "mute-mouse-4739",
+    "type": "streamlit",
+    "include": [
+        ".git"
+    ]
+}
+```
+
+You can specify as many files or directories you want, and this will ensure the files are **always included** in your zipped Ploomber Cloud deployment.
+
+


### PR DESCRIPTION
## Changes

- Adds documentation for the `include` config field in the CLI guide

## Issue

Closes #321 

<!-- readthedocs-preview ploomber-doc start -->
----
📚 Documentation preview 📚: https://ploomber-doc--322.org.readthedocs.build/en/322/

<!-- readthedocs-preview ploomber-doc end -->